### PR TITLE
:sparkles: Expiration improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [<img src="https://img.shields.io/npm/v/@ekwoka/weak-lru-cache?label=%20&style=for-the-badge&logo=pnpm&logoColor=white">](https://www.npmjs.com/package/@ekwoka/weak-lru-cache)
 <img src="https://img.shields.io/npm/types/@ekwoka/weak-lru-cache?label=%20&logo=typescript&logoColor=white&style=for-the-badge">
-<img src="https://img.shields.io/npm/dt/@ekwoka/weak-lru-cache?style=for-the-badge&logo=npm&logoColor=white" >
-[<img src="https://img.shields.io/bundlephobia/minzip/@ekwoka/weak-lru-cache?style=for-the-badge&logo=esbuild&logoColor=white">](https://bundlephobia.com/package/@ekwoka/weak-lru-cache)
+<img src="https://img.shields.io/npm/dt/@ekwoka/weak-lru-cache?style=for-the-badge&logo=npm&logoColor=white&logo=npm&logoColor=white" >
+[<img src="https://img.shields.io/bundlephobia/minzip/@ekwoka/weak-lru-cache?style=for-the-badge&logo=esbuild&logoColor=white&logo=esbuild&logoColor=white">](https://bundlephobia.com/package/@ekwoka/weak-lru-cache)
 <img src="https://img.shields.io/badge/coverage-98%25-success?style=for-the-badge&logo=vitest&logoColor=white" alt="98% test coverage">
 
 This cache allows for items to be stored and maintained while in use, but also allowing for unused items to be garbage collected after they have been sufficiently pushed out by more recently used items.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ This function creates the cache object. It accepts the optional argument of cach
 
 #### `WeakLRUCacheOptions`
 
-- `size?: number` - The maximum number of items that can be stored in the cache. If this is not provided, the cache will be defaulted to 1000 items. As mentioned, this is a soft limit, and more items may be kept in the cache so long as they are still being used.
+- `size?: number` - The maximum size of the Cache. Defaults to `1000`
+- `maxAge?: number` - The maximum age (in seconds) of an item before it is evicted and replaced with a `WeakRef`.
+- `getSize?: (T) => number` - A function for evaluating the size of an item. By default every item is `1` (making the size a length of sorts). With this you can use methods to evaluate the actual memory size of the object to make the cache memory limited. Function will be run on every item when added to the cache, and will be passed the item in question.
 
 ### Properties
 

--- a/scripts/esbuild.js
+++ b/scripts/esbuild.js
@@ -1,5 +1,5 @@
 import { build } from 'esbuild';
-import { writeFile } from 'node:fs/promises';
+import { writeFile, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { gzipSize } from 'gzip-size';
 import prettyBytes from 'pretty-bytes';
@@ -26,9 +26,18 @@ const content = JSON.stringify(
   null,
   2
 );
+const old = JSON.parse(await readFile(join('size.json'), 'utf8'));
 await writeFile(join('size.json'), content, 'utf8');
-console.log(`New Package size: ${minified.pretty}`);
-console.log(`Minzipped size: ${gzipped.pretty}`);
+console.log(
+  `Package size: ${old.minified.pretty} => ${minified.pretty}: ${prettyBytes(
+    minified.raw - old.minified.raw
+  )}`
+);
+console.log(
+  `Minzipped size: ${old.gzipped.pretty} => ${gzipped.pretty}: ${prettyBytes(
+    gzipped.raw - old.gzipped.raw
+  )}`
+);
 
 function sizeInfo(bytesSize) {
   return {

--- a/size.json
+++ b/size.json
@@ -1,10 +1,10 @@
 {
   "minified": {
-    "pretty": "1.72 kB",
-    "raw": 1719
+    "pretty": "1.76 kB",
+    "raw": 1760
   },
   "gzipped": {
-    "pretty": "774 B",
-    "raw": 774
+    "pretty": "777 B",
+    "raw": 777
   }
 }

--- a/size.json
+++ b/size.json
@@ -1,10 +1,10 @@
 {
   "minified": {
-    "pretty": "1.59 kB",
-    "raw": 1595
+    "pretty": "1.72 kB",
+    "raw": 1719
   },
   "gzipped": {
-    "pretty": "714 B",
-    "raw": 714
+    "pretty": "774 B",
+    "raw": 774
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -160,7 +160,7 @@ describe('Weak LRU Cache', () => {
     expect(cache.peekReference('obj0') instanceof WeakRef).toBe(true);
   });
   it('accepts size processor', () => {
-    const sizeCallback = vi.fn().mockImplementation(() => 1);
+    const sizeCallback = vi.fn().mockImplementation(() => 4);
     const cache = WeakLRUCache<{ foo: string }>({
       size: 2,
       getSize: sizeCallback,
@@ -171,6 +171,7 @@ describe('Weak LRU Cache', () => {
     expect(sizeCallback).toBeCalledTimes(2);
     cache.get('obj');
     expect(sizeCallback).toBeCalledTimes(2);
+    expect(cache.peekReference('obj') instanceof WeakRef).toBe(true);
   });
   it('accepts maxAge option', async () => {
     const cache = WeakLRUCache<{ foo: string }>({ maxAge: 1 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -71,6 +71,9 @@ describe('Map API', () => {
 });
 
 describe('Weak LRU Cache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
   it('caches object', () => {
     const cache = WeakLRUCache<{ foo: string }>();
     const obj = { foo: 'bar' };
@@ -155,5 +158,25 @@ describe('Weak LRU Cache', () => {
     const cache = WeakLRUCache<{ foo: string }>({ size: 2 });
     for (let i = 0; i < 3; i++) cache.set(`obj${i}`, { foo: 'bar' });
     expect(cache.peekReference('obj0') instanceof WeakRef).toBe(true);
+  });
+  it('accepts size processor', () => {
+    const sizeCallback = vi.fn().mockImplementation(() => 1);
+    const cache = WeakLRUCache<{ foo: string }>({
+      size: 2,
+      getSize: sizeCallback,
+    });
+    cache.set('obj', { foo: 'bar' });
+    expect(sizeCallback).toBeCalledTimes(1);
+    cache.set('obj', { foo: 'bazz' });
+    expect(sizeCallback).toBeCalledTimes(2);
+    cache.get('obj');
+    expect(sizeCallback).toBeCalledTimes(2);
+  });
+  it('accepts maxAge option', async () => {
+    const cache = WeakLRUCache<{ foo: string }>({ maxAge: 1 });
+    cache.set('obj', { foo: 'bar' });
+    expect(cache.peekReference('obj') instanceof WeakRef).toBeFalsy();
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(cache.peekReference('obj') instanceof WeakRef).toBeTruthy();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,15 +65,14 @@ export const WeakLRUCache = <T extends object>(
     clear: (): void => (cache.forEach(expirer.remove), cache.clear()),
     keys: (): IterableIterator<string> => iterateCache(cache, expirer, 0),
     values: (): IterableIterator<T> => iterateCache(cache, expirer, 1),
-    entries: (): IterableIterator<[string, T]> =>
-      iterateCache(cache, expirer, 2),
+    entries: (): IterableIterator<[string, T]> => iterateCache(cache, expirer),
     [Symbol.iterator]: (): IterableIterator<[string, T]> =>
-      iterateCache(cache, expirer, 2),
+      iterateCache(cache, expirer),
     get size() {
       return cache.size;
     },
     forEach: (cb) => {
-      for (const [key, value] of iterateCache(cache, expirer, 2))
+      for (const [key, value] of iterateCache(cache, expirer))
         cb(value, key, weakLRUCache);
     },
   };
@@ -93,7 +92,7 @@ function iterateCache<T extends object>(
 function iterateCache<T extends object>(
   cache: Map<string, Entry<T>>,
   expirer: Expirer<T>,
-  mode: 2
+  mode?: 2
 ): IterableIterator<[string, T]>;
 function* iterateCache<T extends object>(
   cache: Map<string, Entry<T>>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,14 +20,21 @@ export type WeakLRUCache<T extends object> = {
 };
 
 export const WeakLRUCache = <T extends object>(
-  options: LRUCacheOptions = {}
+  options: LRUCacheOptions<T> = {}
 ): WeakLRUCache<T> => {
   const cache = new Map<string, Entry<T>>();
   const expirer = Expirer<T>(cache, options);
   const weakLRUCache: WeakLRUCache<T> = {
     set: (key: string, value: T): WeakLRUCache<T> => {
-      const entry = cache.get(key) ?? { key, value, next: null, prev: null };
+      const entry = cache.get(key) ?? {
+        key,
+        value,
+        next: null,
+        prev: null,
+        size: 1,
+      };
       entry.value = value;
+      entry.size = options.getSize?.(value) ?? 1;
       cache.set(key, entry);
       expirer.add(expirer.remove(entry)).value as T;
       return weakLRUCache;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,8 +3,12 @@ export type Entry<T extends object> = {
   next: Entry<T> | null;
   prev: Entry<T> | null;
   key: string;
+  timeout?: number | NodeJS.Timeout | null;
+  size: number;
 };
 
-export type LRUCacheOptions = Partial<{
+export type LRUCacheOptions<T> = Partial<{
   size: number;
+  maxAge: number;
+  getSize: (value: T) => number;
 }>;


### PR DESCRIPTION
Adds support for a `maxAge` option as well as a `getSize` object that can be used to control when objects expire.

This opens up opportunities for stricter size tracking if needed.